### PR TITLE
Focus app when Growl notification is clicked

### DIFF
--- a/MacGap/Classes/Commands/Growl.h
+++ b/MacGap/Classes/Commands/Growl.h
@@ -11,5 +11,6 @@
 - (NSString *)applicationNameForGrowl;
 - (NSImage *)applicationIconForGrowl;
 - (NSDictionary *)registrationDictionaryForGrowl;
+- (void) growlNotificationWasClicked:(id)clickContext;
 
 @end

--- a/MacGap/Classes/Commands/Growl.m
+++ b/MacGap/Classes/Commands/Growl.m
@@ -26,7 +26,7 @@
                                    iconData:nil
                                    priority:0
                                    isSticky:false
-                               clickContext:nil];
+                               clickContext:@""];
 }
 
 - (NSString *)applicationNameForGrowl {
@@ -48,6 +48,11 @@
     
 	return ticket;
 }
+
+- (void) growlNotificationWasClicked:(id)clickContext {
+    [NSApp activateIgnoringOtherApps:YES];
+}
+
 
 #pragma mark WebScripting Protocol
 


### PR DESCRIPTION
Currently, clicking on the Growl notification doesn't do anything. This just makes it focus the app (similar to calling `macgap.app.activate()`).
