### PR TITLE
Hide macgap.notice interface when OS X doesn't support it.

### DIFF
--- a/MacGap/Classes/Commands/Notice.h
+++ b/MacGap/Classes/Commands/Notice.h
@@ -15,6 +15,7 @@
 }
 
 - (void) notify:(NSDictionary*)message;
++ (BOOL) available;
 
 @end
 

--- a/MacGap/Classes/Commands/Notice.m
+++ b/MacGap/Classes/Commands/Notice.m
@@ -20,6 +20,13 @@
     [center scheduleNotification:notification];
 }
 
++ (BOOL) available {
+    if ([NSUserNotificationCenter respondsToSelector:@selector(defaultUserNotificationCenter)])
+        return YES;
+    
+    return NO;
+}
+
 #pragma mark WebScripting Protocol
 
 + (BOOL) isSelectorExcludedFromWebScript:(SEL)selector

--- a/MacGap/Classes/WebViewDelegate.m
+++ b/MacGap/Classes/WebViewDelegate.m
@@ -23,7 +23,7 @@
 	if (self.sound == nil) { self.sound = [Sound new]; }
 	if (self.dock == nil) { self.dock = [Dock new]; }
 	if (self.growl == nil) { self.growl = [Growl new]; }
-	if (self.notice == nil) { self.notice = [Notice new]; }
+	if (self.notice == nil && [Notice available] == YES) { self.notice = [Notice new]; }
 	if (self.path == nil) { self.path = [Path new]; }
 	
     if (self.app == nil) { 


### PR DESCRIPTION
This allows the app to use Notification Center when it's available, but
fall back to Growl messages. The app could also choose to always use the Growl
interface.

To test, create an index.html with something like:

```
<script type="text/javascript">
    if (macgap.notice) {
        macgap.notice.notify({title: 'MacGap', content: 'Using native OS X notifications'});
    } else {
        macgap.growl.notify({title: 'MacGap', content: 'Using Growl notifications'});
    }
</script>
```

It should behave differently on OS X Mountain Lion and older versions.

Please note that this essentially breaks API compatibility, although I believe the macgap.notice API was never part of an official release.
