### PR TITLE
Save window size and position.

### DIFF
--- a/MacGap/AppDelegate.m
+++ b/MacGap/AppDelegate.m
@@ -27,9 +27,7 @@
 }
 
 - (void) applicationDidFinishLaunching:(NSNotification *)aNotification { 
-    NSRect frame = NSMakeRect(0, 0, 800, 600);
-    self.windowController = [[WindowController alloc] initWithURL: kStartPage
-                                                         andFrame:frame];
+    self.windowController = [[WindowController alloc] initWithURL: kStartPage];
     [self.windowController showWindow: [NSApplication sharedApplication].delegate];
     self.windowController.contentView.webView.alphaValue = 1.0;
     self.windowController.contentView.alphaValue = 1.0;

--- a/MacGap/Classes/Window.m
+++ b/MacGap/Classes/Window.m
@@ -14,11 +14,7 @@
 
 - (void) open:(NSDictionary *)properties
 {
-    double width  = [[properties valueForKey:@"width"] doubleValue];
-    double height =  [[properties valueForKey:@"height"] doubleValue];
-    
-    NSRect frame = NSMakeRect(0, 0, width, height);
-    self.windowController = [[WindowController alloc] initWithURL:[properties valueForKey:@"url"] andFrame:frame];
+    self.windowController = [[WindowController alloc] initWithURL:[properties valueForKey:@"url"]];
     [self.windowController showWindow: [NSApplication sharedApplication].delegate];
     [self.windowController.window makeKeyWindow];
 }

--- a/MacGap/WindowController.h
+++ b/MacGap/WindowController.h
@@ -5,7 +5,7 @@
     
 }
 
-- (id) initWithURL:(NSString *) url andFrame: (NSRect) frame;
+- (id) initWithURL:(NSString *) url;
 - (id) initWithRequest: (NSURLRequest *)request;
 @property (retain) NSURL * url;
 @property (retain) IBOutlet ContentView *contentView;

--- a/MacGap/WindowController.m
+++ b/MacGap/WindowController.m
@@ -13,11 +13,11 @@
 
 @synthesize  contentView, url;
 
-- (id) initWithURL:(NSString *) relativeURL andFrame: (NSRect) frame{
+- (id) initWithURL:(NSString *) relativeURL{
     self = [super initWithWindowNibName:@"Window"];
     self.url = [NSURL URLWithString:relativeURL relativeToURL:[[NSBundle mainBundle] resourceURL]];
     
-    [self.window setFrame: frame display: YES];
+    [self.window setFrameAutosaveName:@"MacGapWindow"];
     [self notificationCenter];
 
     return self;


### PR DESCRIPTION
Window size can be still set using macgap.window.resize(), but if it's not,
last known window size and position is used. This gives more control to the
end user, who can now resize and reposition the window as they wish.

To test, open a MacGap app, move and resize the window, close the app and start it again.
