### PR TITLE
Allow logging with macgap.app.log

### DIFF
--- a/MacGap/Classes/Commands/App.m
+++ b/MacGap/Classes/Commands/App.m
@@ -42,6 +42,10 @@
     NSBeep();
 }
 
+- (void) log:(NSString*)msg {
+    NSLog(@"%@", msg);
+}
+
 - (void) open:(NSString*)url {
     [[NSWorkspace sharedWorkspace] openURL:[NSURL URLWithString:url]];
 }
@@ -66,6 +70,8 @@
 		result = @"open";
 	} else if (selector == @selector(launch:)) {
         result = @"launch";
+    } else if (selector == @selector(log:)) {
+        result = @"log";
     }
 	
 	return result;


### PR DESCRIPTION
I couldn't find an obvious way to access what's gets written to console.log, so I added this helper function.
