### PR TITLE
properly handle case when user wants to cancel file upload

### DIFF
--- a/MacGap/Classes/WebViewDelegate.m
+++ b/MacGap/Classes/WebViewDelegate.m
@@ -49,8 +49,12 @@
     [openDlg setCanChooseDirectories:NO];
     
     [openDlg beginWithCompletionHandler:^(NSInteger result){
-        NSArray * files = [[openDlg URLs] valueForKey: @"relativePath"];
-        [resultListener chooseFilenames: files]  ;
+        if (result == NSFileHandlingPanelOKButton) {
+            NSArray * files = [[openDlg URLs] valueForKey: @"relativePath"];
+            [resultListener chooseFilenames: files];
+        } else {
+            [resultListener cancel];
+        }
     }];
 }
 


### PR DESCRIPTION
This commit will fix particular problem with file upload.
As it was before this commit: 
 1) click on `<input type=file>` button
 2) select file
 3) hit Cancel button (or Esc)
 4) selected file will be still used as if you clicked Open button

This fix will change that in way that file chooser dialog will work exactly as intended, it won't change anything when you click Cancel.
