### PR TITLE
Extended notification support

### DIFF
--- a/MacGap/Classes/Commands/Notice.h
+++ b/MacGap/Classes/Commands/Notice.h
@@ -7,6 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import "WindowController.h"
 
 #define APP_NOTICE_NOTIFICATION @"Notice"
 
@@ -14,6 +15,9 @@
     
 }
 
+@property (nonatomic, retain) WebView *webView;
+
+- (id) initWithWebView:(WebView *)view;
 - (void) notify:(NSDictionary*)message;
 - (void) close:(NSString*)notificationId;
 + (BOOL) available;

--- a/MacGap/Classes/Commands/Notice.m
+++ b/MacGap/Classes/Commands/Notice.m
@@ -8,7 +8,18 @@
 
 #import "Notice.h"
 
+#import "JSEventHelper.h"
+
 @implementation Notice
+
+- (id) initWithWebView:(WebView*)view
+{
+    if(self = [super init]) {
+        self.webView = view;
+	    [[NSUserNotificationCenter defaultUserNotificationCenter] setDelegate:self];
+    }
+    return self;
+}
 
 - (void) notify:(NSDictionary *)message {
     NSUserNotification *notification = [[NSUserNotification alloc] init];
@@ -53,6 +64,12 @@
         return YES;
     
     return NO;
+}
+
+- (void) userNotificationCenter:(NSUserNotificationCenter *)center didActivateNotification:(NSUserNotification *)notification
+{
+    NSString *notificationId = [notification.userInfo valueForKey:@"id"];
+    [JSEventHelper triggerEvent:@"macgap.notify.activated" forDetail:notificationId forWebView:self.webView];
 }
 
 #pragma mark WebScripting Protocol

--- a/MacGap/Classes/JSEventHelper.h
+++ b/MacGap/Classes/JSEventHelper.h
@@ -13,5 +13,7 @@
 
 + (void) triggerEvent:(NSString *)event forWebView:(WebView *)webView;
 + (void) triggerEvent:(NSString *)event forObject:(NSString *)objName forWebView:(WebView *)webView;
++ (void) triggerEvent:(NSString *)event forDetail:(NSString *)detail forWebView:(WebView *)webView;
++ (void) triggerEvent:(NSString *)event forDetail:(NSString *)detail forObject:(NSString *)objName forWebView:(WebView *)webView;
 
 @end

--- a/MacGap/Classes/JSEventHelper.m
+++ b/MacGap/Classes/JSEventHelper.m
@@ -19,4 +19,13 @@
     [webView stringByEvaluatingJavaScriptFromString:str];
 }
 
++ (void) triggerEvent:(NSString *)event forDetail:(NSString *)detail forWebView:(WebView *)webView {
+    [self triggerEvent:event forDetail:detail forObject:@"document" forWebView:webView];
+}
++ (void) triggerEvent:(NSString *)event forDetail:(NSString *)detail forObject:(NSString *)objName forWebView:(WebView *)webView {
+    NSString *detailEscaped = [detail stringByAddingPercentEscapesUsingEncoding: NSUTF8StringEncoding];
+    NSString *str = [NSString stringWithFormat:@"var e = new CustomEvent('%@', { 'detail': decodeURIComponent(\"%@\") }); %@.dispatchEvent(e); ", event, detailEscaped, objName];
+    [webView stringByEvaluatingJavaScriptFromString:str];
+}
+
 @end

--- a/MacGap/Classes/WebViewDelegate.m
+++ b/MacGap/Classes/WebViewDelegate.m
@@ -25,9 +25,12 @@
 	if (self.sound == nil) { self.sound = [Sound new]; }
 	if (self.dock == nil) { self.dock = [Dock new]; }
 	if (self.growl == nil) { self.growl = [Growl new]; }
-	if (self.notice == nil && [Notice available] == YES) { self.notice = [Notice new]; }
 	if (self.path == nil) { self.path = [Path new]; }
 	if (self.clipboard == nil) { self.clipboard = [Clipboard new]; }
+
+    if (self.notice == nil && [Notice available] == YES) {
+       self.notice = [[Notice alloc] initWithWebView:webView];
+    }
 	
     if (self.app == nil) { 
         self.app = [[App alloc] initWithWebView:webView]; 

--- a/README.md
+++ b/README.md
@@ -127,6 +127,9 @@ Events:
     //Mac OS X on sleep event.
     document.addEventListener('sleep', function(){console.log('Sleep!!')}, true);
 
+    // User clicked on Native User notification
+    document.addEventListener('macgap.notify.activated', function(e) {console.log('notified: id = ' + e.detail)}, true);
+
 ##Offline Patterns
 
 Desktop apps load immediately and work offline, whilst web apps have the advantage of being easily updated and remotely managed. MacGap gives you the best of both worlds via HTML5's offline APIs.


### PR DESCRIPTION
This commits give ability to do few new things with native notifications: disable sound, close notifications and listening for activate event (to simulate onclick event on Chrome`s notifications).
