### PR TITLE
Add ability to set custom user agent string.

### DIFF
--- a/MacGap/Classes/Commands/App.h
+++ b/MacGap/Classes/Commands/App.h
@@ -16,5 +16,6 @@
 - (void) unhide;
 - (void) beep;
 - (void) bounce;
+- (void) setCustomUserAgent:(NSString *)userAgentString;
 
 @end

--- a/MacGap/Classes/Commands/App.m
+++ b/MacGap/Classes/Commands/App.m
@@ -46,6 +46,10 @@
     [NSApp requestUserAttention:NSInformationalRequest];
 }
 
+- (void)setCustomUserAgent:(NSString *)userAgentString {
+    [self.webView setCustomUserAgent: userAgentString];
+}
+
 - (void) open:(NSString*)url {
     [[NSWorkspace sharedWorkspace] openURL:[NSURL URLWithString:url]];
 }
@@ -70,9 +74,11 @@
 		result = @"open";
 	} else if (selector == @selector(launch:)) {
         result = @"launch";
+    } else if (selector == @selector(setCustomUserAgent:)) {
+        result = @"setCustomUserAgent";
     }
-	
-	return result;
+
+    return result;
 }
 
 + (BOOL) isSelectorExcludedFromWebScript:(SEL)selector

--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ App:
     // Launch application
     macgap.app.launch("TextEdit");
 
+	// Set a custom user agent string
+	macgap.app.setCustomUserAgent('new user agent string');
+	
 Clipboard:
 
     // copy text to clipboard


### PR DESCRIPTION
As per issue at https://github.com/maccman/macgap/issues/88:

```
    // Set a custom user agent string
    macgap.app.setCustomUserAgent('new user agent string');
```
