### PR TITLE
command macgap.localfile.read("path/to/file")

### DIFF
--- a/MacGap.xcodeproj/project.pbxproj
+++ b/MacGap.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		1495814F15C15CCC00E1CFE5 /* Notice.m in Sources */ = {isa = PBXBuildFile; fileRef = 1495814E15C15CCC00E1CFE5 /* Notice.m */; };
+		70CE270018D5B52B00024D3D /* Localfile.m in Sources */ = {isa = PBXBuildFile; fileRef = 70CE26FF18D5B52B00024D3D /* Localfile.m */; };
 		88746BEE14CCA435001E160E /* JSEventHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 88746BED14CCA435001E160E /* JSEventHelper.m */; };
 		88C0646014BDE10A00E4BCE2 /* Window.m in Sources */ = {isa = PBXBuildFile; fileRef = 88C0645F14BDE10A00E4BCE2 /* Window.m */; };
 		88C0646614BDEC5800E4BCE2 /* Window.xib in Resources */ = {isa = PBXBuildFile; fileRef = 88C0646414BDEC5800E4BCE2 /* Window.xib */; };
@@ -50,6 +51,8 @@
 /* Begin PBXFileReference section */
 		1495814D15C15CCC00E1CFE5 /* Notice.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Notice.h; path = Classes/Commands/Notice.h; sourceTree = "<group>"; };
 		1495814E15C15CCC00E1CFE5 /* Notice.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = Notice.m; path = Classes/Commands/Notice.m; sourceTree = "<group>"; };
+		70CE26FE18D5B52B00024D3D /* Localfile.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Localfile.h; path = Classes/Commands/Localfile.h; sourceTree = "<group>"; };
+		70CE26FF18D5B52B00024D3D /* Localfile.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = Localfile.m; path = Classes/Commands/Localfile.m; sourceTree = "<group>"; };
 		88746BEC14CCA435001E160E /* JSEventHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = JSEventHelper.h; path = Classes/JSEventHelper.h; sourceTree = "<group>"; };
 		88746BED14CCA435001E160E /* JSEventHelper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = JSEventHelper.m; path = Classes/JSEventHelper.m; sourceTree = "<group>"; };
 		88C0645E14BDE10A00E4BCE2 /* Window.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Window.h; path = Classes/Window.h; sourceTree = "<group>"; };
@@ -149,6 +152,8 @@
 				88746BED14CCA435001E160E /* JSEventHelper.m */,
 				F2B80014179E0FC100B069A8 /* Clipboard.h */,
 				F2B80015179E0FC100B069A8 /* Clipboard.m */,
+				70CE26FE18D5B52B00024D3D /* Localfile.h */,
+				70CE26FF18D5B52B00024D3D /* Localfile.m */,
 			);
 			name = Commands;
 			sourceTree = "<group>";
@@ -301,6 +306,7 @@
 				88C0646014BDE10A00E4BCE2 /* Window.m in Sources */,
 				88C0646D14BDF6A600E4BCE2 /* WindowController.m in Sources */,
 				88746BEE14CCA435001E160E /* JSEventHelper.m in Sources */,
+				70CE270018D5B52B00024D3D /* Localfile.m in Sources */,
 				1495814F15C15CCC00E1CFE5 /* Notice.m in Sources */,
 				F2B80016179E0FC100B069A8 /* Clipboard.m in Sources */,
 			);

--- a/MacGap/Classes/Commands/Localfile.h
+++ b/MacGap/Classes/Commands/Localfile.h
@@ -1,0 +1,15 @@
+//
+//  Localfile.h
+//  Kato
+//
+//  Created by JLarky on 16.03.14.
+//  Copyright (c) 2014 LeChat, Inc. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface Localfile : NSObject
+
+- (NSString *) read:(NSString*)fileNeeded;
+
+@end

--- a/MacGap/Classes/Commands/Localfile.m
+++ b/MacGap/Classes/Commands/Localfile.m
@@ -1,0 +1,78 @@
+//
+//  Localfile.m
+//  Kato
+//
+//  Created by JLarky on 16.03.14.
+//  Copyright (c) 2014 LeChat, Inc. All rights reserved.
+//
+
+#import "Localfile.h"
+
+@implementation Localfile
+
+- (NSString *) read:(NSString*)fileNeeded {
+    NSDictionary *result = [NSDictionary dictionaryWithObjectsAndKeys:@"unknown", @"error", nil];
+    NSString *whitelistFile = [[Utils sharedInstance] pathForResource:@"public/localfiles.whitelist"];
+    if (!whitelistFile) {
+        result = [NSDictionary dictionaryWithObjectsAndKeys:@"localfiles.whitelist can't be read", @"error", nil];
+    } else {
+        NSString* fileContents =
+            [NSString stringWithContentsOfFile:whitelistFile
+             encoding:NSUTF8StringEncoding error:nil];
+        // separate by new line
+        NSArray* allLinedStrings =
+            [fileContents componentsSeparatedByCharactersInSet:
+             [NSCharacterSet newlineCharacterSet]];
+        // search for fileNeeded in whitelist
+        if ([allLinedStrings indexOfObject:fileNeeded] == NSNotFound) {
+            result = [NSDictionary dictionaryWithObjectsAndKeys:@"requested file not in localfiles.whitelist", @"error", nil];
+        } else {
+            NSString *filename;
+            NSString *resourceFile = [[Utils sharedInstance] pathForResource:fileNeeded];
+            if (resourceFile) {
+                filename = resourceFile;
+            } else {
+                filename =[fileNeeded stringByExpandingTildeInPath];
+            }
+            NSError *readError = nil;
+            NSString* content =
+                [NSString stringWithContentsOfFile:filename
+                 encoding:NSUTF8StringEncoding
+                 error:&readError];
+            if (readError) {
+                result = [NSDictionary dictionaryWithObjectsAndKeys:[readError localizedDescription], @"error", nil];
+            } else {
+                result = [NSDictionary dictionaryWithObjectsAndKeys:content, @"content", nil];
+            }
+        }
+    }
+    NSError *writeError = nil;
+    NSData *jsonData = [NSJSONSerialization dataWithJSONObject:result options:NSJSONWritingPrettyPrinted error:&writeError];
+    NSString *jsonString = [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
+    return jsonString;
+}
+
+// macgap.localfile.read("~/Library/Application Support/Kato/userstyle.css")
+
++ (NSString*) webScriptNameForSelector:(SEL)selector
+{
+	id	result = nil;
+	
+	if (selector == @selector(read:)) {
+        result = @"read";
+    }
+	
+	return result;
+}
+
++ (BOOL) isSelectorExcludedFromWebScript:(SEL)selector
+{
+    return NO;
+}
+
++ (BOOL) isKeyExcludedFromWebScript:(const char*)name
+{
+	return YES;
+}
+
+@end

--- a/MacGap/Classes/WebViewDelegate.h
+++ b/MacGap/Classes/WebViewDelegate.h
@@ -6,6 +6,7 @@
 @class Growl;
 @class Notice;
 @class Path;
+@class Localfile;
 @class App;
 @class Window;
 @class Clipboard;
@@ -18,6 +19,7 @@
     Growl* growl;
     Notice* notice;
     Path* path;
+    Localfile* localfile;
     App* app;
     Window* window;
     Clipboard* clipboard;
@@ -30,6 +32,7 @@
 @property (nonatomic, retain) Growl* growl;
 @property (nonatomic, retain) Notice* notice;
 @property (nonatomic, retain) Path* path;
+@property (nonatomic, retain) Localfile* localfile;
 @property (nonatomic, retain) App* app;
 @property (nonatomic, retain) Window* window;
 @property (nonatomic, retain) Clipboard* clipboard;

--- a/MacGap/Classes/WebViewDelegate.m
+++ b/MacGap/Classes/WebViewDelegate.m
@@ -4,6 +4,7 @@
 #import "Growl.h"
 #import "Notice.h"
 #import "Path.h"
+#import "Localfile.h"
 #import "App.h"
 #import "Window.h"
 #import "WindowController.h"
@@ -15,6 +16,7 @@
 @synthesize growl;
 @synthesize notice;
 @synthesize path;
+@synthesize localfile;
 @synthesize app;
 @synthesize window;
 @synthesize requestedWindow;
@@ -27,6 +29,7 @@
 	if (self.growl == nil) { self.growl = [Growl new]; }
 	if (self.notice == nil && [Notice available] == YES) { self.notice = [Notice new]; }
 	if (self.path == nil) { self.path = [Path new]; }
+	if (self.localfile == nil) { self.localfile = [Localfile new]; }
 	if (self.clipboard == nil) { self.clipboard = [Clipboard new]; }
 	
     if (self.app == nil) { 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@ Path:
     // Path to application's resources
     macgap.path.resource;
 
+Local files:
+    // read local file (must be included in public/localfiles.whitelist)
+    macgap.localfile.read('~/file.txt');
+
 Dock:
 
     // Set the Dock's badge

--- a/public/localfiles.whitelist
+++ b/public/localfiles.whitelist
@@ -1,0 +1,2 @@
+public/userstyle.css
+public/userscript.js


### PR DESCRIPTION
that allows to read files from filesystem as long as filename is whitelisted

One can use that to include user provided css or scripts. Example

webapp:

``` javascript
if (window.macgap.localfile) {
    var json = macgap.localfile.read("~/my_app_userstyle.css");
    if (json) {
        response = $.parseJSON(json);
        if (response && response.content) {
            css = response.content;
            var styleNode = document.createElement('style');
            styleNode.type = "text/css";
            var styleText = document.createTextNode(css);
            styleNode.appendChild(styleText);
            document.getElementsByTagName('head')[0].appendChild(styleNode);
        }
    }
}
```

and in public/localfiles.whitelist

```
~/my_app_userstyle.css
```
