### PR TITLE
Allow Obj-C to trigger JavaScript events containing additional key-value data

### DIFF
--- a/MacGap/Classes/JSEventHelper.h
+++ b/MacGap/Classes/JSEventHelper.h
@@ -12,6 +12,7 @@
 @interface JSEventHelper : NSObject
 
 + (void) triggerEvent:(NSString *)event forWebView:(WebView *)webView;
-+ (void) triggerEvent:(NSString *)event forObject:(NSString *)objName forWebView:(WebView *)webView;
++ (void) triggerEvent:(NSString *)event withArgs:(NSDictionary *)args forWebView:(WebView *)webView;
++ (void) triggerEvent:(NSString *)event withArgs:(NSDictionary *)args forObject:(NSString *)objName forWebView:(WebView *)webView;
 
 @end

--- a/MacGap/Classes/JSEventHelper.m
+++ b/MacGap/Classes/JSEventHelper.m
@@ -11,11 +11,32 @@
 @implementation JSEventHelper
 
 + (void) triggerEvent:(NSString *)event forWebView:(WebView *)webView {
-    [self triggerEvent:event forObject:@"document" forWebView:webView];
+    [self triggerEvent:event withArgs:[NSMutableDictionary dictionary] forObject:@"document" forWebView:webView];
 }
 
-+ (void) triggerEvent:(NSString *)event forObject:(NSString *)objName forWebView:(WebView *)webView {
-    NSString * str = [NSString stringWithFormat:@"var e = document.createEvent('Events'); e.initEvent('%@', true, false); %@.dispatchEvent(e); ", event, objName];
++ (void) triggerEvent:(NSString *)event withArgs:(NSDictionary *)args forWebView:(WebView *)webView {
+    [self triggerEvent:event withArgs:args forObject:@"document" forWebView:webView];
+}
+
++ (void) triggerEvent:(NSString *)event withArgs:(NSDictionary *)args forObject:(NSString *)objName forWebView:(WebView *)webView {
+    
+    // Convert args Dictionary to JSON.
+    NSError *error;
+    NSData *jsonData = [NSJSONSerialization
+                        dataWithJSONObject:args
+                        options:NSJSONWritingPrettyPrinted // Pass 0 if you don't care about the readability of the generated string
+                        error:&error];
+    
+    NSString *jsonString;
+    if (! jsonData) {
+        NSLog(@"Got an error converting to JSON: %@", error);
+    }
+    else {
+        jsonString = [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
+    }
+    
+    // Create the event JavaScript and run it.
+    NSString * str = [NSString stringWithFormat:@"var e = document.createEvent('Events'); e.initEvent('%@', true, false);  e.data=%@; %@.dispatchEvent(e); ", event, jsonString, objName];
     [webView stringByEvaluatingJavaScriptFromString:str];
 }
 


### PR DESCRIPTION
This adds the ability for the MacGap triggerEvent method to trigger an event on the JavaScript side, which contains a data object.

This is useful in numerous cases, and extends the triggerEvent method in a small but useful way.

For example, if the NSWorkspace detects a NSWorkspaceDidActivateApplicationNotification, it's helpful to pass information about the activated application back to the JavaScript event handler.

Javascript:

```
document.addEventListener('didActivateApplication', function(e){
    console.log(e.data);
}, true);
```
