### PR TITLE
Add title for the window

### DIFF
--- a/MacGap/Classes/Window.m
+++ b/MacGap/Classes/Window.m
@@ -16,6 +16,7 @@
 {
     self.windowController = [[WindowController alloc] initWithURL:[properties valueForKey:@"url"]];
     [self.windowController showWindow: [NSApplication sharedApplication].delegate];
+    [self.windowController.window setTitle:[properties valueForKey:@"title"]];
     [self.windowController.window makeKeyWindow];
 }
 


### PR DESCRIPTION
Add a Title key so we can add to the window.

Usage: macgap.window.open({title:"My Window Title", url:"public/index2.html", width: 400, height: 300});
