### PR TITLE
Menu API Enhancements

### DIFF
--- a/MacGap.xcodeproj/project.xcworkspace/xcshareddata/MacGap.xccheckout
+++ b/MacGap.xcodeproj/project.xcworkspace/xcshareddata/MacGap.xccheckout
@@ -5,36 +5,36 @@
 	<key>IDESourceControlProjectFavoriteDictionaryKey</key>
 	<false/>
 	<key>IDESourceControlProjectIdentifier</key>
-	<string>0F3B07D6-40A5-44C4-86A3-BF7328FF1B31</string>
+	<string>4D486E78-E297-4CC3-AAAE-1A58EDAC87E6</string>
 	<key>IDESourceControlProjectName</key>
 	<string>MacGap</string>
 	<key>IDESourceControlProjectOriginsDictionary</key>
 	<dict>
-		<key>D4E1D36A-DEC6-413E-BFDB-6EE992B8369C</key>
-		<string>https://github.com/maccman/macgap.git</string>
+		<key>E290DE2F-0285-42FA-BA1D-7AF656980698</key>
+		<string>https://github.com/rawcreative/macgap.git</string>
 	</dict>
 	<key>IDESourceControlProjectPath</key>
 	<string>MacGap.xcodeproj/project.xcworkspace</string>
 	<key>IDESourceControlProjectRelativeInstallPathDictionary</key>
 	<dict>
-		<key>D4E1D36A-DEC6-413E-BFDB-6EE992B8369C</key>
+		<key>E290DE2F-0285-42FA-BA1D-7AF656980698</key>
 		<string>../..</string>
 	</dict>
 	<key>IDESourceControlProjectURL</key>
-	<string>https://github.com/maccman/macgap.git</string>
+	<string>https://github.com/rawcreative/macgap.git</string>
 	<key>IDESourceControlProjectVersion</key>
 	<integer>110</integer>
 	<key>IDESourceControlProjectWCCIdentifier</key>
-	<string>D4E1D36A-DEC6-413E-BFDB-6EE992B8369C</string>
+	<string>E290DE2F-0285-42FA-BA1D-7AF656980698</string>
 	<key>IDESourceControlProjectWCConfigurations</key>
 	<array>
 		<dict>
 			<key>IDESourceControlRepositoryExtensionIdentifierKey</key>
 			<string>public.vcs.git</string>
 			<key>IDESourceControlWCCIdentifierKey</key>
-			<string>D4E1D36A-DEC6-413E-BFDB-6EE992B8369C</string>
+			<string>E290DE2F-0285-42FA-BA1D-7AF656980698</string>
 			<key>IDESourceControlWCCName</key>
-			<string>macgap-clean</string>
+			<string>MGFork</string>
 		</dict>
 	</array>
 </dict>

--- a/MacGap/Classes/Commands/MenuItemProxy.h
+++ b/MacGap/Classes/Commands/MenuItemProxy.h
@@ -21,9 +21,11 @@
 - (MenuProxy*)addSubmenu;
 
 - (void) remove;
-- (void)setCallback:(WebScriptObject*)aCallback;
-- (void)setKey:(NSString*)keyCommand;
+- (void) setCallback:(WebScriptObject*)aCallback;
+- (void) setKey:(NSString*)keyCommand;
 - (void) setTitle:(NSString*)title;
+- (void) enable;
+- (void) disable;
 - (MenuProxy*)submenu;
 
 @end

--- a/MacGap/Classes/Commands/MenuItemProxy.m
+++ b/MacGap/Classes/Commands/MenuItemProxy.m
@@ -93,6 +93,16 @@
     return [MenuProxy proxyWithContext:context andMenu:s];
 }
 
+- (void) enable
+{
+    [item setEnabled:YES];
+}
+
+- (void) disable
+{
+    [item setEnabled:NO];
+}
+
 #pragma mark WebScripting protocol
 
 + (BOOL) isSelectorExcludedFromWebScript:(SEL)selector
@@ -126,6 +136,12 @@
 	}
 	else if (selector == @selector(submenu)) {
 		result = @"submenu";
+	}
+    else if (selector == @selector(enable)) {
+		result = @"enable";
+	}
+    else if (selector == @selector(disable)) {
+		result = @"disable";
 	}
 	
 	return result;

--- a/MacGap/Classes/Commands/MenuProxy.h
+++ b/MacGap/Classes/Commands/MenuProxy.h
@@ -16,11 +16,14 @@
 
 + (MenuProxy*)proxyWithContext:(JSContextRef)aContext andMenu:(NSMenu*)aMenu;
 
-- (MenuItemProxy*)addItemWithTitle:(NSString*)title 
+- (MenuItemProxy*)addItemWithTitle:(NSString*)title
                      keyEquivalent:(NSString*)aKey
-                          callback:(WebScriptObject*)aCallback;
+                          callback:(WebScriptObject*)aCallback
+                           atIndex:(NSInteger)index;
+
 - (MenuItemProxy*)addSeparator;
 - (MenuItemProxy*)itemForKey:(id)key;
+- (MenuProxy*)removeItem:(id)key;
 
 + (NSString*)getKeyFromString:(NSString*)keyCommand;
 + (NSUInteger*)getModifiersFromString:(NSString*)keyCommand;


### PR DESCRIPTION
Adds additional functionality and flexibility to the menu API as well as fixing #110
## Changes
### addItem()

This method now allows for adding root level menu items as well as specifying the menu position, with the additional 'index' argument. 

```
//Syntax: addItem(Label, Shorcut Keys, Callback, Index);
//Add a root level menu
macgap.menu.addItem('Foo', 'cmd+g', function() { alert('yay'); }, 1);

//Add an item to existing menu
 macgap.menu.getItem('File').submenu().addItem('Foo', 'cmd+g', function() { alert('yay'); }, 1);
```

The index parameter is optional for both root level and submenus, excluding it will add the menu item to the end of the menu.
## Additions
### removeMenu(ID)

Added removeMenu shortcut which now allows: 

```
macgap.menu.removeMenu('File');
```

instead of the more verbose

```
macgap.menu.getItem('File').remove(). 
```

MenuItemProxy now uses this method to remove items as well.
### enable() & disable()

Added enable() and disable() methods to MenuItemProxy which allows for enabling and disabling menu items via js

```
// Disable the Save menu item
macgap.menu.getItem('File').submenu().getItem('Save').disable();

// Enable the Save menu item
macgap.menu.getItem('File').submenu().getItem('Save').enable();
```

I debated removing the need to use .submenu() and instead return the submenu automatically when calling getItem() but decided to keep it in for now as it would remove the ability to change the title/accelerator keys and callbacks for the root level menu items unless additional methods were implemented to deal with those.

Ideally I'd like to make creating/editing menus much easier by passing a simply JS object with the desired menu configuration but doing so would require writing a ton of C code to parse the object and it just doesn't seem to be worthwhile to do for the time being. It can easily be done with the 10.9 JavascriptCore api so it may be something to look into for the MacGapNode project.
