### PR TITLE
Add pasteImage API to handle paste image

### DIFF
--- a/MacGap/Clipboard.h
+++ b/MacGap/Clipboard.h
@@ -6,5 +6,6 @@
 
 - (void) copy:(NSString*)text;
 - (NSString *) paste;
+- (NSString *) pasteImage;
 
 @end

--- a/MacGap/Clipboard.m
+++ b/MacGap/Clipboard.m
@@ -27,6 +27,24 @@
     return @"";
 }
 
+- (NSString *) pasteImage {
+    NSPasteboard *pasteboard = [NSPasteboard generalPasteboard];
+    NSArray *classArray = [NSArray arrayWithObject:[NSImage class]];
+    NSDictionary *options = [NSDictionary dictionary];
+    BOOL ok = [pasteboard canReadObjectForClasses:classArray options:options];
+    if (ok) {
+        NSArray *objectsToPaste = [pasteboard readObjectsForClasses:classArray options:options];
+        NSImage *image = [objectsToPaste objectAtIndex:0];
+        [image lockFocus];
+        NSBitmapImageRep *bitmapRep = [[NSBitmapImageRep alloc] initWithFocusedViewRect:NSMakeRect(0, 0, image.size.width, image.size.height)];
+        [image unlockFocus];
+        NSData *imageData = [bitmapRep representationUsingType:NSPNGFileType properties:nil];;
+        NSString *base64String = [imageData base64EncodedStringWithOptions:0];
+        return base64String;
+    }
+    return @"";
+}
+
 + (NSString*) webScriptNameForSelector:(SEL)selector
 {
 	id	result = nil;


### PR DESCRIPTION
The API will return BASE64 string format of Image. You can add "data:image/png;base64," prefix and set to <img> src attribute, it will be shown as html5 data uri image.

If you want to mock a html5 File Object to upload or do some other things. There is the code:

``` javascript
var imgData = window.macgap.clipboard.pasteImage();
if (!imgData) return;
var byteString = window.atob(imgData);
var ia = new Uint8Array(byteString.length);
for (var i = 0; i < byteString.length; i++) {
  ia[i] = byteString.charCodeAt(i);
}
var file = new Blob([ia], {type: 'image/png', encoding: 'utf-8'});
```
